### PR TITLE
Update ruby-install version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,11 +3,11 @@ chruby_chruby_version: 0.3.9
 chruby_chruby_checksum: 7220a96e355b8a613929881c091ca85ec809153988d7d691299e0a16806b42fd
 chruby_chruby_exec_command: /usr/local/bin/chruby-exec
 
-chruby_ruby_install_version: 0.6.1
-chruby_ruby_install_checksum: b3adf199f8cd8f8d4a6176ab605db9ddd8521df8dbb2212f58f7b8273ed85e73
+chruby_ruby_install_version: 0.8.3
+chruby_ruby_install_checksum: e2f69949757d032d48ee5c028be020bdc8863c41d5648b53328903d2e16ab3b2
 chruby_ruby_install_command: /usr/local/bin/ruby-install
 
-chruby_ruby_version: ruby-2.4.1
+chruby_ruby_version: ruby-2.6.6
 
 # These ruby versions will be removed if they are found:
 #chruby_outdated_ruby_versions: []


### PR DESCRIPTION
This application downloads ruby. The older version attempts to download bz2 archives which are no longer published by the ruby maintainers. 

This also updates a variable that specifies the ruby version. This variable isn't actually used by our other roles/playbooks.